### PR TITLE
Fixed enterFullscreenfunction.

### DIFF
--- a/src/TSPlayer.ts
+++ b/src/TSPlayer.ts
@@ -612,7 +612,11 @@ class TSPlayer extends AddEvent{
             media.webkitRequestFullScreen();
         }
         setTimeout(()=> { 
-            this.isFullscreen = true;
+            if (window.screenTop || window.screenY){
+                this.isFullscreen = false
+            } else {
+                this.isFullscreen = true
+            }
         } , 1000)
         this.doMethodArray(this.fullscreenEnter);
     }


### PR DESCRIPTION
Some device cannot go to fullscreen, so that on enterFullscreenfunction we check "window.screenTop || window.screenY"
